### PR TITLE
Update the server URL

### DIFF
--- a/AvaMSN/Utils/SettingsManager.cs
+++ b/AvaMSN/Utils/SettingsManager.cs
@@ -20,7 +20,7 @@ public static class SettingsManager
     public static Settings Settings { get; set; } = new Settings()
     {
         // Default settings
-        Server = "crosstalksrv.hiden.pw",
+        Server = "crosstalksrv.hiden.cc",
         SaveMessagingHistory = true,
         MinimizeToTray = true
     };

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 An Avalonia MSNP15 client. It's compatible with Linux, Windows and MacOS.
 
 ## Server
-The default server is [CrossTalk](https://crosstalk.hiden.pw), which is currently in private alpha. That can be changed in the options window, however, to any server supporting version 15 of the protocol.
+The default server is [CrossTalk](https://crosstalk.hiden.cc), which is currently in private alpha. That can be changed in the options window, however, to any server supporting version 15 of the protocol.
 
 ## To do
 - [x] Come up with a better way to do the "remember your password" feature


### PR DESCRIPTION
The CrossTalk service is no longer operational on the old .pw domain. 